### PR TITLE
Crawler now has an iterator interface, which the main program uses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         .ignore_untracked(cli.ignore_untracked)
         .absolute_paths(cli.absolute_paths)
         .untagged_heads(cli.untagged_heads);
-    for result in crawler.run() {
+    for result in crawler.iter() {
         if let Some(path) = result.path {
             print!("{}", path.display());
         }


### PR DESCRIPTION
Straightforward, _once_ I sorted out the lifetime issues. You'll note that `Output` no longer needs a lifetime, because that would have made things extra interesting.  It feels a lot more snappy, because the results come in as they become available.
